### PR TITLE
Let public be protected for fixtures method

### DIFF
--- a/tests/WAQITest.php
+++ b/tests/WAQITest.php
@@ -40,7 +40,7 @@ class WAQITest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -53,7 +53,7 @@ class WAQITest extends TestCase
      *
      * @return void
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 


### PR DESCRIPTION
# Changed log

- According to the [PHPUnit fixtures](https://phpunit.readthedocs.io/en/latest/fixtures.html?highlight=fixtures) reference, the `setUp` and `tearDown` methods should be `protected`, not `public`.