### PR TITLE
Fix invalid 'php' argument input

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.3', '7.4', '8.0']
+        php-version: ['7.3', '7.4', '8.0']
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
It needs to be "php-version" and not "php". Which is why at the moment it gives you a warning saying the 'php' input is invalid https://github.com/azuyalabs/waqi/actions/runs/1312450761

<img width="745" alt="Screenshot 2022-01-14 at 7 58 59 AM" src="https://user-images.githubusercontent.com/1325411/149412517-5b3ebe64-2223-4e00-97de-fa5270172696.png">


Hope it helps!